### PR TITLE
Refactor twomes names to their new names excluding backoffice api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# NeedForHeat App<!-- omit in toc -->
-![GitHub License](https://img.shields.io/github/license/energietransitie/twomes-app-needforheat)
+# NeedForHeat GearUp App<!-- omit in toc -->
+![GitHub License](https://img.shields.io/github/license/energietransitie/needforheat-gearup-app)
 ![Project Status badge](https://img.shields.io/badge/status-in%20progress-brightgreen)
 ![Version Status Badge](https://img.shields.io/badge/version-stable-brightgreen)
 
-This repository contains the source code for the NeedForHeat (NFH) app for both Android and iOS. The app helps users to install and connect one or more NFH measurement devices that start collecting monitoring data related to home heating.
+This repository contains the source code for the GearUp version of the NeedForHeat (NFH) app for both Android and iOS. The app helps users to install and connect one or more NFH measurement devices that start collecting monitoring data related to home heating.
 
 ## Table of contents<!-- omit in toc -->
 - [General info](#general-info)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NeedForHeat GearUp App<!-- omit in toc -->
 ![GitHub License](https://img.shields.io/github/license/energietransitie/needforheat-gearup-app)
 ![Project Status badge](https://img.shields.io/badge/status-in%20progress-brightgreen)
-![Version Status Badge](https://img.shields.io/badge/version-stable-brightgreen)
+![Version Status Badge](https://img.shields.io/badge/version-beta-orange)
 
 This repository contains the source code for the GearUp version of the NeedForHeat (NFH) app for both Android and iOS. The app helps users to install and connect one or more NFH measurement devices that start collecting monitoring data related to home heating.
 

--- a/apps/expo/README.md
+++ b/apps/expo/README.md
@@ -1,2 +1,2 @@
-# NeedForHeat
+# NeedForHeat GearUp
 Read all about this project in the [main README file](../../README.md) that is in the root of this repository.

--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -58,7 +58,7 @@
     "react-native-bluetooth-state-manager": "1.3.4",
     "react-native-chart-kit": "6.12.0",
     "react-native-dotenv": "3.4.8",
-    "react-native-esp-idf-provisioning": "ssh://git@github.com/energietransitie/twomes-app-needforheat-eup",
+    "react-native-esp-idf-provisioning": "ssh://git@github.com/energietransitie/needforheat-gearup-app-eup",
     "react-native-exit-app": "^1.1.0",
     "react-native-gesture-handler": "2.8.0",
     "react-native-permissions": "3.6.1",

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -26,7 +26,7 @@ This guide will explain how to prepare the local enviroment to start developing 
     - [Cocaopods](https://cocoapods.org/) (>=1.15.2)
 
 ## 1. Setup SSH Key
-Due to the dependency [twomes-app-needforheat-eup](https://github.com/energietransitie/twomes-app-needforheat-eup), a SSH key will be required to set up so Yarn can properly fetch this repo.
+Due to the dependency [needforheat-gearup-app-eup](https://github.com/energietransitie/needforheat-gearup-app-eup), a SSH key will be required to set up so Yarn can properly fetch this repo.
 
 To do this, please follow the GitHub documentation to setup an SSH key on the device you will be using to develop:
 1. [Generate a new SSH key](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent)
@@ -79,7 +79,7 @@ Otherwise, the Java JDK inside this folder will be used when building which is m
 ## 6. Prepare and Running with Expo Go
 You SHOULD read the guides for [Android](./android.md) and [iOS](./ios.md) for the OS-specific guide. These guides will explain how to prepare your environment to build the development app on either a emulator or a physical device.
 
-Do note that you should not exclusively develop on Expo Go. Mainly because icons will not load and because of React Native Bindings that get used from [twomes-app-needforheat-eup](https://github.com/energietransitie/twomes-app-needforheat-eup). 
+Do note that you should not exclusively develop on Expo Go. Mainly because icons will not load and because of React Native Bindings that get used from [needforheat-gearup-app-eup](needforheat-gearup-app-eup). 
 
 In addition, Expo Go requires that the network is a **private** network with a firewall that allows the Expo Go ports to go through on the PC hosting the Expo Go server. This means you will be unable to use Expo Go on public networks like `eduroam`. \
 You *can* fix this by running through a hotspot or and/or setting the network to private for [Windows](https://support.microsoft.com/en-us/windows/make-a-wi-fi-network-public-or-private-in-windows-0460117d-8d3e-a7ac-f003-7a0da607448d). MacOS has no public/private network setting and should work fine on private networks.

--- a/docs/github.md
+++ b/docs/github.md
@@ -1,8 +1,8 @@
 # GitHub documentation
-This file aims to explain the workflows and pullrequest template that are used as part of GitHub in [the .github/ folder](https://github.com/energietransitie/twomes-app-needforheat/tree/main/.github).
+This file aims to explain the workflows and pullrequest template that are used as part of GitHub in [the .github/ folder](https://github.com/energietransitie/needforheat-gearup-app/tree/main/.github).
 
 ## Pull Request Template
-The template can be read in the [PULL_REQUEST_TEMPLATE.md](https://github.com/energietransitie/twomes-app-needforheat/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1).
+The template can be read in the [PULL_REQUEST_TEMPLATE.md](https://github.com/energietransitie/needforheat-gearup-app/blob/main/.github/PULL_REQUEST_TEMPLATE.md?plain=1).
 
 This template should be filled in for every pullrequest to ensure that reviewers know what the pullrequest is about.
 

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -146,7 +146,7 @@ and select the physical device to get the QR-code that you can scan on the iOS d
 ### 3.2. Release version on the iOS device
 To install the release version of the, select the release schema in Xcode in the top-menu where it says `NeedforHeat` next to the iOS device selection and then select `NeedforHeat Release`.
 
-![Change Xcode scheme to Release](https://github.com/energietransitie/twomes-app-needforheat/assets/16213031/7619856f-6dc6-42c2-a4cb-976faea140e5)
+![Change Xcode scheme to Release](https://github.com/energietransitie/needforheat-gearup-app/assets/16213031/7619856f-6dc6-42c2-a4cb-976faea140e5)
 
 Then you can build the app as release version and automatically install to your iOS device. When you open it up, you will get the release version without Expo Go and thus see the app open up immediatley without Metro bundling. \
 You might still see a terminal open with Metro bundler which you can ignore

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -126,4 +126,4 @@ The `docs` folder contains as much of the documentation in this repository as po
 ## .env
 All environment variables for the whole repository can be found here.
 
-Setup can be found [here](https://github.com/energietransitie/twomes-app-needforheat/blob/docs/revamp/docs/developing.md#4-add-environment-variable).
+Setup can be found [here](https://github.com/energietransitie/needforheat-gearup-app/blob/docs/revamp/docs/developing.md#4-add-environment-variable).

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -126,4 +126,4 @@ The `docs` folder contains as much of the documentation in this repository as po
 ## .env
 All environment variables for the whole repository can be found here.
 
-Setup can be found [here](https://github.com/energietransitie/needforheat-gearup-app/blob/docs/revamp/docs/developing.md#4-add-environment-variable).
+Setup can be found [here](https://github.com/energietransitie/needforheat-gearup-app/blob/main/docs/developing.md#4-add-environment-variable).

--- a/yarn.lock
+++ b/yarn.lock
@@ -11464,9 +11464,9 @@ react-native-dotenv@3.4.8:
   dependencies:
     dotenv "^16.0.3"
 
-"react-native-esp-idf-provisioning@ssh://git@github.com/energietransitie/twomes-app-needforheat-eup":
+"react-native-esp-idf-provisioning@ssh://git@github.com/energietransitie/needforheat-gearup-app-eup":
   version "0.1.0"
-  resolved "ssh://git@github.com/energietransitie/twomes-app-needforheat-eup#a166a46ace76ca000d52c638de9072a993963bc8"
+  resolved "ssh://git@github.com/energietransitie/needforheat-gearup-app-eup#a166a46ace76ca000d52c638de9072a993963bc8"
 
 react-native-exit-app@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
### Checklist
- [x] Tests have been written/updated (if necessary)
  - [x] All tests are passing
- [x] Docs have been updated (if necessary)
- [x] Updated `Linear` issue to `In Review`

### Description
This RP renames most of the former twomes references to their new ones while also updating the links.

### Linked Issues
https://trello.com/c/SYDwF14R/1101-rename-github-repo-twomes-app-needforhet-needforheat-gearup-app-and-update-references-to-this-repo
https://github.com/Labhatorian/NeedForHeat-GearUp-ProjectIssues/issues/148

### Additional context
Some links/names are not ready yet to be changed, but to prevent issues with `eup` as that one is needed by Yarn, this PR will be created.
