### PR TITLE
Hot Fix: Broken app due to babel

### DIFF
--- a/apps/expo/babel.config.js
+++ b/apps/expo/babel.config.js
@@ -20,8 +20,9 @@ module.exports = function (api) {
           },
         },
       ],
-      "@babel/plugin-proposal-class-properties",
-      "@babel/plugin-proposal-private-methods",
+      //[DO NOT UNCOMMENT!] WILL CRASH THE APP - TESTING NOT POSSIBLE ON REACT NATIVE
+      //"@babel/plugin-proposal-class-properties",
+      //"@babel/plugin-proposal-private-methods",
       "react-native-reanimated/plugin",
     ],
   };


### PR DESCRIPTION
Emergency hotfix.

Old Babel settings will crash the app. Unit Testing is not viable with React Native.